### PR TITLE
Switch to jinja templating

### DIFF
--- a/poast/__init__.py
+++ b/poast/__init__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import io
-import string
 import pymongo
 import os
 from email import message_from_string
+from jinja2 import Environment
 
-from .mail import create_message, authors
+from .mail import create_message, authors, pluralize, format_num
 from .config import Config
 
 
@@ -15,8 +15,11 @@ def message_queue(cfg=Config()):
                                   cfg['MONGO_COLLECTION'])
     addresser = address_service(cfg)
     threshold = cfg['DOWNLOAD_THRESHOLD']
+    environment = Environment()
+    environment.filters['pluralize'] = pluralize
+    environment.filters['format_num'] = format_num
     with io.open(cfg['EMAIL_TEMPLATE']) as fp:
-        template = string.Template(fp.read())
+        template = environment.from_string(fp.read())
     for author in authors(collection, addresser, threshold):
         yield create_message(cfg['EMAIL_SENDER'], cfg['EMAIL_SUBJECT'],
                              author, template)

--- a/poast/mail.py
+++ b/poast/mail.py
@@ -23,7 +23,7 @@ def create_message(sender, subject, context, template):
     msg['From'] = sender
     msg['Subject'] = subject
     msg['Content-Transfer-Encoding'] = 'Quoted-Printable'
-    msg.set_payload(template.substitute(context), 'utf-8')
+    msg.set_payload(template.render(context), 'utf-8')
     return msg
 
 
@@ -45,3 +45,19 @@ def authors(collection, addresser, threshold):
                 'articles': item['size'],
                 'countries': len(list(filter(None, countries)))
             }
+
+
+def pluralize(count, single, plural):
+    if count > 1:
+        return plural
+    else:
+        return single
+
+
+def format_num(number):
+    chars = []
+    for i, n in enumerate(str(number)[::-1]):
+        if i and not (i % 3):
+            chars.insert(0, ',')
+        chars.insert(0, n)
+    return ''.join(chars)

--- a/poast/message.tmpl
+++ b/poast/message.tmpl
@@ -1,8 +1,8 @@
-Dear Professor ${author},
+Dear Professor {{author}},
 
 Thank you for sharing your scholarly articles through the open repository DSpace@MIT <http://dspace.mit.edu/handle/1721.1/49433/>, in association with the MIT Faculty Open Access Policy <http://libraries.mit.edu/oapolicy>.
 
-Your ${articles} articles have been downloaded ${downloads} times since the last time we reported, from ${countries} different countries.
+Your {{articles|format_num}} {{ articles|pluralize("article has", "articles have") }} been downloaded {{downloads|format_num}} times since {{ articles|pluralize("it was", "they were") }} deposited, from {{countries}} {{ countries|pluralize("country", "different countries") }}.
 
 To see more detailed download information, including per-article and per-country downloads, visit <http://oastats.mit.edu>.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+Jinja2==2.7.3
+MarkupSafe==0.23
 PyYAML==3.11
 click==3.3
 cx-Oracle==5.1.3

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -2,9 +2,9 @@
 from __future__ import absolute_import
 import unittest
 from mock import Mock, MagicMock
-from string import Template
+from jinja2 import Template
 
-from poast.mail import threshold_filter, create_message, authors
+from poast.mail import *
 
 
 class ThresholdFilterTestCase(unittest.TestCase):
@@ -20,7 +20,7 @@ class ThresholdFilterTestCase(unittest.TestCase):
 
 class CreateMessageTestCase(unittest.TestCase):
     def setUp(self):
-        self.tmpl = Template(u'${author}: ${downloads}')
+        self.tmpl = Template(u'{{author}}: {{downloads}}')
         self.ctx = {'author': u'Guðrún', 'downloads': 1, 'email': 'foo@example.com'}
 
     def testSetsToAddress(self):
@@ -62,3 +62,17 @@ class AuthorsTestCase(unittest.TestCase):
             'author': 'Foo Bar', 'email': 'foobar@example.com', 'downloads': 10,
             'articles': 2, 'countries': 2,
         })
+
+
+class TemplateFiltersTestCase(unittest.TestCase):
+    def testPluralizeReturnsPluralForMoreThanOne(self):
+        self.assertEqual(pluralize(2, 'foobar', 'foobars'), 'foobars')
+
+    def testPluralizeReturnsSingleForOne(self):
+        self.assertEqual(pluralize(1, 'foobar', 'foobars'), 'foobar')
+
+    def testFormatNumAddsCommas(self):
+        self.assertEqual(format_num(123), '123')
+        self.assertEqual(format_num(1234), '1,234')
+        self.assertEqual(format_num(12345), '12,345')
+        self.assertEqual(format_num(1234567), '1,234,567')


### PR DESCRIPTION
Using Jinja2 for templating to make pluralizing and number formatting
a bit easier.
