### PR TITLE
Use SQLAlchemy to access the database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ env:
   - TOX_ENV=py33
   - TOX_ENV=py34
   - TOX_ENV=coveralls
-before_install:
-  - "sed -i '/^cx-Oracle/s/^/#/' requirements.txt"
 install:
   - pip install tox
 script:

--- a/poast/config/default.yml
+++ b/poast/config/default.yml
@@ -9,8 +9,4 @@ SMTP_HOST: 'localhost'
 
 DOWNLOAD_THRESHOLD: 20
 
-ORACLE_USER:  # <username>
-ORACLE_PASSWORD:  # <password>
-ORACLE_SID: DWRHS
-ORACLE_HOST: warehouse.mit.edu
-ORACLE_PORT: 1521
+SQLALCHEMY_DB_URI: 'sqlite://'

--- a/poast/mail.py
+++ b/poast/mail.py
@@ -32,32 +32,32 @@ def authors(collection, addresser, threshold):
     t_filter = partial(threshold_filter, threshold=threshold)
     totals = global_context(collection)
     emails = []
-    with addresser as svc:
-        for item in ifilter(t_filter, collection.find({'type': 'author'})):
-            try:
-                first_name, last_name, email = svc.lookup(item['_id']['mitid'])
-            except TypeError:
-                logger.warning('Author not found: %s (%s)' %
-                               (item['_id']['name'], item['_id']['mitid']))
-                continue
-            if not email:
-                logger.warning('Author missing email: %s (%s)' %
-                               (item['_id']['name'], item['_id']['mitid']))
-                continue
-            if email in emails:
-                logger.warning('Duplicate email: %s' % (email,))
-                continue
-            emails.append(email)
-            countries = [x['downloads'] for x in item['countries']]
-            yield {
-                'author': u"%s %s" % (first_name, last_name),
-                'email': email,
-                'downloads': item['downloads'],
-                'articles': item['size'],
-                'countries': len(list(filter(None, countries))),
-                'total_size': totals['size'],
-                'total_countries': totals['countries'],
-            }
+    for item in ifilter(t_filter, collection.find({'type': 'author'})):
+        try:
+            first_name, last_name, email = \
+                addresser.lookup(item['_id']['mitid'])
+        except TypeError:
+            logger.warning('Author not found: %s (%s)' %
+                           (item['_id']['name'], item['_id']['mitid']))
+            continue
+        if not email:
+            logger.warning('Author missing email: %s (%s)' %
+                           (item['_id']['name'], item['_id']['mitid']))
+            continue
+        if email in emails:
+            logger.warning('Duplicate email: %s' % (email,))
+            continue
+        emails.append(email)
+        countries = [x['downloads'] for x in item['countries']]
+        yield {
+            'author': u"%s %s" % (first_name, last_name),
+            'email': email,
+            'downloads': item['downloads'],
+            'articles': item['size'],
+            'countries': len(list(filter(None, countries))),
+            'total_size': totals['size'],
+            'total_countries': totals['countries'],
+        }
 
 
 def pluralize(count, single, plural):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ Jinja2==2.8
 MarkupSafe==0.23
 pymongo==3.1.1
 PyYAML==3.11
+SQLAlchemy==1.0.9
 wheel==0.24.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import io
+import json
+import os
+
+import pytest
+
+from poast.addresses import engine, persons, metadata
+
+
+@pytest.fixture(scope="session", autouse=True)
+def db():
+    data = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                        'fixtures/people.json')
+    with io.open(data, encoding="utf-8") as fp:
+        people = json.load(fp)
+    engine.configure('sqlite://')
+    metadata.bind = engine()
+    metadata.create_all()
+    conn = engine().connect()
+    conn.execute(persons.insert(), people)
+    conn.close()

--- a/tests/fixtures/people.json
+++ b/tests/fixtures/people.json
@@ -1,0 +1,11 @@
+[{
+    "first_name": "Foo",
+    "last_name": "Bar",
+    "mit_id": "1234",
+    "email": "foobar@example.com"
+}, {
+    "first_name": "Þorgerðr",
+    "last_name": "Hǫlgabrúðr",
+    "mit_id": "0987",
+    "email": "thor@example.com"
+}]


### PR DESCRIPTION
This replaces the hard requirement for cx_Oracle with an SQLAlchemy
abstraction layer. Mostly, this makes testing easier.
