### PR TITLE
Remove provisional port binding

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import asyncore
 import io
 import json
 import os
-import socket
 import shutil
 import smtpd
 import tempfile
@@ -60,26 +59,17 @@ def tmp_dir():
 
 @pytest.yield_fixture
 def smtp_server():
-    port = _get_open_port()
-    server = TestSMTPServer(('localhost', port))
+    server = TestSMTPServer(('localhost', 0))
     server.start()
     yield server
     server.close()
 
 
-def _get_open_port(host="localhost"):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind((host, 0))
-    port = s.getsockname()[1]
-    s.close()
-    return port
-
-
 class TestSMTPServer(smtpd.SMTPServer):
     def __init__(self, localaddr):
         self.received = {}
-        self._port = localaddr[1]
         smtpd.SMTPServer.__init__(self, localaddr, None)
+        self._port = self.socket.getsockname()[1]
 
     def process_message(self, peer, mailfrom, rcpttos, data):
         self.received[rcpttos[0]] = data


### PR DESCRIPTION
Functionally, this change should be the same, just without the race
condition.
